### PR TITLE
#27: Add CI/CD Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release Pipeline
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  backend:
+    name: Test Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Run backend tests
+        working-directory: backend/dockerhub-clone
+        run: mvn -B clean verify
+
+  frontend:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm install
+
+      - name: Run frontend build (lint/tests included)
+        working-directory: frontend
+        run: npm run build


### PR DESCRIPTION
Implements CI/CD pipeline for the main branch.

- Added GitHub Actions workflow `release.yml`.
- Workflow runs backend (Maven) and frontend (Node.js) tests.
- Triggered on `push` to main.
- Simplified: no Docker build/push, just test execution.

Closes #27 